### PR TITLE
Fix 1.6x distance multiplication bug in GPS to playa coordinate conversion

### DIFF
--- a/Docs/2025-08-21-fix-distance-multiplication.md
+++ b/Docs/2025-08-21-fix-distance-multiplication.md
@@ -1,0 +1,55 @@
+# Fix for 1.6x Distance Multiplication Issue
+
+## Problem
+GPS to playa coordinate conversion was reporting distances approximately 1.6 times larger than actual distances. For example:
+- ARTery at 2400' from the Man was showing as ~3856'
+- Point 2 at 8337' was showing as ~13396'  
+- 1500' locations showed as ~2506'
+
+## Root Cause
+The issue was caused by a breaking change between Turf.js v3 and v7. The project was upgraded to Turf v7 but still used the old v3 syntax for distance calculations.
+
+**The 1.6x multiplication factor = 1.609344 (the conversion between kilometers and miles)**
+
+### Technical Details
+- **Turf v3 syntax**: `turf.distance(point1, point2, 'miles')` returned miles
+- **Turf v7 with old syntax**: `turf.distance(point1, point2, 'miles')` returns **kilometers** (ignores string parameter)
+- **Turf v7 correct syntax**: `turf.distance(point1, point2, {units: 'miles'})` returns miles
+
+## Files Fixed
+
+### Source Code
+1. **src/geocoder/reverse.js:82** - Critical fix for reverse geocoding
+   - Changed from: `turf.distance(point, this.cityCenter, 'miles')`  
+   - Changed to: `turf.distance(point, this.cityCenter, {units: 'miles'})`
+
+2. **src/brc_diff.js:37** - Translation distance calculation
+   - Changed from: `turf.distance(goldenSpike1, goldenSpike2, 'miles')`
+   - Changed to: `turf.distance(goldenSpike1, goldenSpike2, {units: 'miles'})`
+
+3. **src/wiki.js:7** - Already using kilometers, updated for consistency
+   - Changed from: `turf.distance(turf.point(lastYearCenter), turf.point(thisYearCenter), 'kilometers')`
+   - Changed to: `turf.distance(turf.point(lastYearCenter), turf.point(thisYearCenter), {units: 'kilometers'})`
+
+### Test Files
+4. **tests/GeocoderTest.js** - Updated multiple turf.distance calls and corrected expected distance values
+5. **tests/ArtGeocodeTest.js** - Updated turf.distance call
+
+## New Tests Added
+Created **tests/ReverseGeocoderDistanceTest.js** with comprehensive tests:
+- Validates distances are calculated in miles, not kilometers
+- Tests known locations (ARTery, Point 2, etc.) have correct distances
+- Verifies reverse geocode distances match forward geocode
+- Confirms the fix eliminates the 1.6x multiplication
+
+## Verification
+All tests now pass with correct distance calculations:
+- ARTery correctly shows as 2400' from the Man
+- Point 2 correctly shows as 8337' from the Man
+- All other distances are now accurate without the 1.6x multiplication
+
+## Impact
+This fix ensures accurate distance reporting for:
+- GPS location to playa coordinate conversion
+- Reverse geocoding from lat/lon to Burning Man addresses
+- Distance calculations throughout the application

--- a/src/brc_diff.js
+++ b/src/brc_diff.js
@@ -34,7 +34,7 @@ request(dataUrl1, function (error1, response1, body1) {
         var goldenSpike2 = extractGoldenSpike(parsed2.data);
         //var pentagon2 = extractPentagon(parsed2.data);
 
-        var translation = turf.distance(goldenSpike1, goldenSpike2, 'miles');
+        var translation = turf.distance(goldenSpike1, goldenSpike2, {units: 'miles'});
         console.log('Golden spike offset ' + translation + ' miles');
         console.log('Golden spike lat delt: ' + (goldenSpike2.geometry.coordinates[1] - goldenSpike1.geometry.coordinates[1]));
         console.log('Golden spike lon delt: ' + (goldenSpike2.geometry.coordinates[0] - goldenSpike1.geometry.coordinates[0]));

--- a/src/geocoder/reverse.js
+++ b/src/geocoder/reverse.js
@@ -79,7 +79,7 @@ var streetResult = function(point,features) {
 reverseGeocoder.prototype.playaResult = function(point, polygon) {
   var bearing = turf.bearing(this.cityCenter,point);
   var time = utils.degreesToTime(bearing,this.cityBearing);
-  var distance = turf.distance(point,this.cityCenter, 'miles');
+  var distance = turf.distance(point,this.cityCenter, {units: 'miles'});
   var feet = utils.milesToFeet(distance);
 
   return time +" & "+ Math.round(feet) +'\' ' + polygon.properties.name;

--- a/src/wiki.js
+++ b/src/wiki.js
@@ -4,7 +4,7 @@ var leven = require('levenshtein');
 var lastYearCenter = [-119.20315, 40.78880];
 var thisYearCenter = [-119.2065, 40.7864];
 
-var distance = turf.distance(turf.point(lastYearCenter),turf.point(thisYearCenter),'kilometers');
+var distance = turf.distance(turf.point(lastYearCenter),turf.point(thisYearCenter),{units: 'kilometers'});
 var bearing = turf.bearing(turf.point(lastYearCenter),turf.point(thisYearCenter));
 
 // Loose string match score above this value results in auto-match

--- a/tests/ArtGeocodeTest.js
+++ b/tests/ArtGeocodeTest.js
@@ -44,7 +44,7 @@ test('geocodingArtStringJSON', function(t) {
 
 
 
-	        var distance = turf.distance(point,realPoint);
+	        var distance = turf.distance(point,realPoint, {units: 'kilometers'});
 	        //t.ok(distance < .001, "Distance is close enough "+ (distance*1000.0) +" meters");
 			if (distance > .001) {
 				var testError = {};

--- a/tests/GeocoderTest.js
+++ b/tests/GeocoderTest.js
@@ -28,7 +28,7 @@ test ('StreetIntersection', function(t) {
             t.fail("No intersection found for " + testIntersection.properties.time + " & " + testIntersection.properties.street);
             continue;
         }
-        var distanceDifference = turf.distance(intersection,testIntersection);
+        var distanceDifference = turf.distance(intersection,testIntersection, {units: 'kilometers'});
         t.ok(distanceDifference < 0.001, "Intersection should be close "+distanceDifference+" expected: "+testIntersection.geometry.coordinates+" got: "+intersection.geometry.coordinates);
 
         intersection = coder.forward(testIntersection.properties.street +' & '+testIntersection.properties.time);
@@ -36,7 +36,7 @@ test ('StreetIntersection', function(t) {
             t.fail("No intersection found for forward: " + testIntersection.properties.street +' & '+testIntersection.properties.time);
             continue;
         }
-        distanceDifference = turf.distance(intersection,testIntersection);
+        distanceDifference = turf.distance(intersection,testIntersection, {units: 'kilometers'});
         t.ok(distanceDifference < 0.001, "Intersection should be close "+distanceDifference);
 
         intersection = coder.forward(testIntersection.properties.time +' & '+testIntersection.properties.street);
@@ -44,7 +44,7 @@ test ('StreetIntersection', function(t) {
             t.fail("No intersection found for forward: " + testIntersection.properties.time +' & '+testIntersection.properties.street);
             continue;
         }
-        distanceDifference = turf.distance(intersection,testIntersection);
+        distanceDifference = turf.distance(intersection,testIntersection, {units: 'kilometers'});
         t.ok(distanceDifference < 0.001, "Intersection should be close "+testIntersection.properties.street+" "+distanceDifference);
     }
 
@@ -88,13 +88,13 @@ test("geocode",function(t){
         t.ok(twoStringIntersection, "Checking valid intersection returned for: "+JSON.stringify(item.properties));
 
         if (fullStringIntersection) {
-            var fullStringDistance = turf.distance(item,fullStringIntersection);
+            var fullStringDistance = turf.distance(item,fullStringIntersection, {units: 'kilometers'});
             var tolerance = item.properties.tolerance || 0.001;
             t.ok(fullStringDistance < tolerance, "Full string intersection should be close "+fullStringDistance+ " "+JSON.stringify(fullStringIntersection));
         }
 
         if (twoStringIntersection) {
-            var twoStringDistace = turf.distance(item,twoStringIntersection);
+            var twoStringDistace = turf.distance(item,twoStringIntersection, {units: 'kilometers'});
             var tolerance = item.properties.tolerance || 0.001;
             t.ok(twoStringDistace < tolerance, "Two string intersection should be close "+twoStringDistace+ " "+JSON.stringify(twoStringIntersection));
         }
@@ -211,13 +211,13 @@ test('reverseGeocode',function(t) {
     t.equal(result,"10:30 & 0' Inner Playa","Center coordinates test");
     
     result = coder.reverse(40.787858, -119.204994);
-    t.equal(result,"8:31 & 1034' Inner Playa","Inner Playa coordinates test");
+    t.equal(result,"8:31 & 643' Inner Playa","Inner Playa coordinates test");
     
     result = coder.reverse(40.78518066835633, -119.21173504230462);
-    t.equal(result,"7:00 & 4023' Inner Playa","Esplanade intersection test");
+    t.equal(result,"7:00 & 2500' Inner Playa","Esplanade intersection test");
     
     result = coder.reverse(40.79, -119.2);
-    t.equal(result,"11:43 & 2227' Inner Playa","Northern area test");
+    t.equal(result,"11:43 & 1384' Inner Playa","Northern area test");
     
     result = coder.reverse(40.78, -119.22);
     t.equal(result,"6:33 & Ishiguro","Street intersection test");

--- a/tests/ReverseGeocoderDistanceTest.js
+++ b/tests/ReverseGeocoderDistanceTest.js
@@ -1,0 +1,155 @@
+var test = require('tape');
+var Geocoder = require('../src/geocoder/geocoder.js');
+var layout2025 = require('./layout2025.json');
+var turf = require('@turf/turf');
+var utils = require('../src/utils.js');
+
+test('Distance calculations use correct units (miles not kilometers)', function(t) {
+    var coder = new Geocoder(layout2025);
+    
+    // Test known locations with their expected distances from the Man
+    var testCases = [
+        // ARTery should be about 2400' from the Man
+        { location: "10:30 & 2400'", expectedFeet: 2400, tolerance: 50 },
+        // Point 2 should be about 8337' from the Man
+        { location: "3:00 & 8337'", expectedFeet: 8337, tolerance: 50 },
+        // Test various distances
+        { location: "6:00 & 1500'", expectedFeet: 1500, tolerance: 50 },
+        { location: "9:00 & 2300'", expectedFeet: 2300, tolerance: 50 },
+        { location: "12:00 & 500'", expectedFeet: 500, tolerance: 50 },
+        { location: "4:30 & 1000'", expectedFeet: 1000, tolerance: 50 }
+    ];
+    
+    testCases.forEach(function(testCase) {
+        // Forward geocode the location
+        var point = coder.forward(testCase.location);
+        if (!point) {
+            t.fail("Could not forward geocode: " + testCase.location);
+            return;
+        }
+        
+        // Calculate distance from the Man
+        var distance = turf.distance(point, layout2025.center, {units: 'miles'});
+        var calculatedFeet = Math.round(utils.milesToFeet(distance));
+        
+        // Check if the distance is correct (not multiplied by 1.6)
+        var difference = Math.abs(calculatedFeet - testCase.expectedFeet);
+        t.ok(difference <= testCase.tolerance, 
+             testCase.location + " should be ~" + testCase.expectedFeet + "' from Man, " +
+             "calculated: " + calculatedFeet + "' (diff: " + difference + "')");
+    });
+    
+    t.end();
+});
+
+test('Reverse geocode distances match forward geocode', function(t) {
+    var coder = new Geocoder(layout2025);
+    
+    var testLocations = [
+        "10:30 & 2400'",
+        "3:00 & 1500'", 
+        "6:00 & 2000'",
+        "9:00 & 3000'",
+        "12:00 & 500'"
+    ];
+    
+    testLocations.forEach(function(originalLocation) {
+        // Forward geocode to get coordinates
+        var point = coder.forward(originalLocation);
+        if (!point) {
+            t.fail("Could not forward geocode: " + originalLocation);
+            return;
+        }
+        
+        // Reverse geocode back to location string
+        var reverseLocation = coder.reverse(
+            point.geometry.coordinates[1], 
+            point.geometry.coordinates[0]
+        );
+        
+        // Extract distance from reverse geocoded string
+        var match = reverseLocation.match(/(\d+)'/);
+        if (match) {
+            var reverseFeet = parseInt(match[1]);
+            
+            // Extract expected distance from original
+            var expectedMatch = originalLocation.match(/(\d+)'/);
+            if (expectedMatch) {
+                var expectedFeet = parseInt(expectedMatch[1]);
+                
+                // Allow some tolerance due to rounding
+                var difference = Math.abs(reverseFeet - expectedFeet);
+                t.ok(difference <= 10, 
+                     "Reverse geocode of " + originalLocation + " returned: " + reverseLocation + 
+                     " (difference: " + difference + " feet)");
+            }
+        }
+    });
+    
+    t.end();
+});
+
+test('turf.distance with old vs new syntax', function(t) {
+    // This test validates that we're using the correct turf v7 syntax
+    var point1 = turf.point([-119.2133, 40.7864]);
+    var point2 = turf.point([-119.2033, 40.7864]);
+    
+    // Old syntax (returns kilometers in turf v7, even when 'miles' is specified)
+    var distanceOldSyntax = turf.distance(point1, point2, 'miles');
+    
+    // New syntax (correctly returns miles)
+    var distanceNewSyntax = turf.distance(point1, point2, {units: 'miles'});
+    
+    // The ratio should be ~1.609 (km to miles conversion)
+    var ratio = distanceOldSyntax / distanceNewSyntax;
+    
+    t.ok(Math.abs(ratio - 1.609344) < 0.01, 
+         "Old syntax returns kilometers (ratio should be ~1.609): " + ratio.toFixed(3));
+    
+    // Verify the new syntax returns the correct value in miles
+    t.ok(distanceNewSyntax < distanceOldSyntax, 
+         "New syntax should return smaller value (miles < km)");
+    
+    t.end();
+});
+
+test('Verify no 1.6x multiplication in playa distances', function(t) {
+    var coder = new Geocoder(layout2025);
+    
+    // Test coordinates that are at known distances
+    // These are approximate coordinates for testing
+    var testPoints = [
+        { 
+            lat: 40.788, 
+            lon: -119.206,
+            maxExpectedFeet: 3000  // Should be less than 3000' from Man
+        },
+        { 
+            lat: 40.790, 
+            lon: -119.203,
+            maxExpectedFeet: 4000  // Should be less than 4000' from Man
+        }
+    ];
+    
+    testPoints.forEach(function(testPoint) {
+        var reverseResult = coder.reverse(testPoint.lat, testPoint.lon);
+        
+        // Extract distance from result
+        var match = reverseResult.match(/(\d+)'/);
+        if (match) {
+            var feet = parseInt(match[1]);
+            
+            // Check that it's not multiplied by 1.6
+            t.ok(feet < testPoint.maxExpectedFeet, 
+                 "Distance at (" + testPoint.lat + ", " + testPoint.lon + ") " +
+                 "should be < " + testPoint.maxExpectedFeet + "', got: " + feet + "'");
+            
+            // Also check it's not the 1.6x inflated value
+            var inflatedValue = Math.round(testPoint.maxExpectedFeet * 1.6);
+            t.ok(feet < inflatedValue / 2, 
+                 "Distance should not be inflated by 1.6x");
+        }
+    });
+    
+    t.end();
+});


### PR DESCRIPTION
## Summary
- Fixes GPS to playa coordinate conversion reporting distances 1.6x larger than actual
- Root cause: Breaking change between Turf.js v3 and v7 syntax
- The 1.6x factor was exactly the km to miles conversion (1.609344)

## Problem
Distances from the Man were being incorrectly multiplied by ~1.6:
- ARTery at 2400' was showing as ~3856'
- Point 2 at 8337' was showing as ~13396'  
- 1500' locations showed as ~2506'

## Solution
Updated all `turf.distance()` calls from the old v3 string syntax to the new v7 object syntax:
```javascript
// OLD (returns kilometers in v7):
turf.distance(point, center, 'miles')

// NEW (correctly returns miles):
turf.distance(point, center, {units: 'miles'})
```

## Changes
- ✅ Fixed distance calculations in `reverse.js`, `brc_diff.js`, and `wiki.js`
- ✅ Updated test files to use correct syntax and expected values
- ✅ Added comprehensive unit tests in `ReverseGeocoderDistanceTest.js`
- ✅ All tests passing with correct distance calculations

## Test Plan
- [x] Run `npm test` - all tests pass
- [x] Verify ARTery shows as 2400' from Man (not 3856')
- [x] Verify Point 2 shows as 8337' from Man (not 13396')
- [x] New unit tests validate the fix and prevent regression

🤖 Generated with [Claude Code](https://claude.ai/code)